### PR TITLE
fix: "no file" warning crash

### DIFF
--- a/CD_Measure.py
+++ b/CD_Measure.py
@@ -876,6 +876,6 @@ class mApp(QtWidgets.QWidget):  # PySide2
     def initUI(self, msg):
         self.setGeometry(100, 100, 400, 300)
         self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
-        QtGui.QMessageBox.question(self, 'Warning', msg, QtGui.QMessageBox.Ok|QtGui.QMessageBox.Ok)
+        QtWidgets.QMessageBox.question(self, 'Warning', msg, QtWidgets.QMessageBox.Ok|QtWidgets.QMessageBox.Ok)
         self.show()
 


### PR DESCRIPTION
FC 0.21.0 Portable on Windows 10, warning when no file is opened fails:
```
Running the Python command 'QuickMeasureTool' failed:
Traceback (most recent call last):
  File "(...)\CD_Measure.py", line 849, in Activated
    mApp('No file is opened.You must open a file first.')
  File "(...)\CD_Measure.py", line 874, in __init__
    self.initUI(msg)
  File "(...)\CD_Measure.py", line 879, in initUI
    QtGui.QMessageBox.question(self, 'Warning', msg, QtGui.QMessageBox.Ok|QtGui.QMessageBox.Ok)

module 'PySide2.QtGui' has no attribute 'QMessageBox'
```
Replaced QtGui.QMessageBox with QtWidgets.QMessageBox and it works